### PR TITLE
ci: run CI on Node 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
         node-version:
           - 20.x
           - 22.x
+          - 24.x
     with:
       node-version: ${{ matrix.node-version }}
   code-tests:


### PR DESCRIPTION
Not enabled for Prepare Release workflow since it'll be superseded by #123