### PR TITLE
ci: use Node 24 only on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,14 +29,6 @@ jobs:
   code-check:
     name: Run Code Check Workflow
     uses: ./.github/workflows/code-check.yaml
-    strategy:
-      matrix:
-        node-version:
-          - 20.x
-          - 22.x
-          - 24.x
-    with:
-      node-version: ${{ matrix.node-version }}
   code-tests:
     name: Run Tests Workflow
     uses: ./.github/workflows/code-test.yaml

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -9,7 +9,7 @@ on:
         type: string
       node-version:
         description: Node.js version
-        default: lts/*
+        default: latest
         type: string
 
 jobs:
@@ -37,9 +37,6 @@ jobs:
 
       - name: Build website
         run: pnpm build:website
-
-      # - name: Check formatting
-      #   run: pnpm check:format
 
       - name: Check linting
         run: pnpm check:lint


### PR DESCRIPTION
Again, ignoring `release` and `prepare-release` workflows since they will be superseded.